### PR TITLE
fix: reply-to-comment.sh Node ID handling and clarify interleaved loop flow

### DIFF
--- a/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
+++ b/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
@@ -47,54 +47,60 @@ Task tool:
   prompt: |
     Execute the PR review feedback loop for PR #<PR>.
 
+    ⚠️ CRITICAL: Each round must include ALL reviewer types (Gemini, other bots, agents)
+    BEFORE triggering the next review. Do NOT run multiple Gemini rounds first.
+
     **Setup (first round only):**
     - Check for AGENT-REVIEWERS.md files in changed directories (up to repo root)
+    - Parse the # Agents section to discover agent reviewers
     - Load non-Agents H1 sections (e.g., # Guidelines, # Context) as review context
-    - Apply hierarchical scoping: lower directories override same-named sections
 
-    **Each round of the loop:**
+    **Each round of the loop (ALL steps before triggering next review):**
 
-    1. **Get Gemini comments**:
+    1. **Get Gemini comments** (do NOT use --wait after first round):
        - scripts/summarize-reviews.sh <PR>
-       - scripts/get-review-comments.sh <PR> --with-ids --wait
+       - scripts/get-review-comments.sh <PR> --with-ids
 
-    2. **Address Gemini comments** - For EACH comment:
+    2. **Address ALL Gemini comments** - For EACH comment:
        - If worthwhile: fix it, reply "Fixed - [description]"
        - If bad suggestion: reply "Won't fix - [reason]"
-       - If GOOD but out of scope: check `bd --version`, if beads available create ticket with full context (see "Out of Scope Suggestions"), reply "Out of scope - tracked in BD-XXX"
+       - If GOOD but out of scope: reply "Out of scope - tracked in BD-XXX" (create beads ticket if `bd --version` works)
 
     3. **Check for other bot PR comments** (Claude, Cursor, Copilot):
-       - These post single PR comments (not line comments) with multiple issues
+       - gh pr view <PR> --json comments --jq '.comments[] | select(.author.login | test("claude|cursor|copilot"; "i"))'
+       - These post single PR comments with multiple issues
        - Parse the structured markdown to extract individual issues
-       - Reply with `gh pr comment` addressing each issue (see "Comment Formats" section)
 
-    4. **Run agent reviewers** (if AGENT-REVIEWERS.md exists and agents not retired):
-       - Spawn non-retired agents as parallel Tasks
+    4. **Address ALL other bot comments**:
+       - Reply with `gh pr comment` addressing each issue
+
+    5. **Run agent reviewers** (if AGENT-REVIEWERS.md exists and agents not retired):
+       - Spawn non-retired agents as parallel Tasks (multiple Task calls in ONE message)
        - Wait for all agents to return
-       - Address agent comments (same fix/wontfix/out-of-scope flow)
+
+    6. **Address ALL agent comments**:
+       - Same fix/wontfix/out-of-scope flow as Gemini
        - Track per-agent diminishing returns - retire agents with no actionable feedback
 
-    5. **Commit and push** (if any fixes were made):
+    7. **Commit and push** (if ANY fixes were made in steps 2, 4, or 6):
        - scripts/commit-and-push.sh "fix: address review comments"
 
-    6. **Trigger next review round**:
+    8. **Trigger next review round**:
        - scripts/trigger-review.sh <PR> --wait
        - Go to step 1
 
     **Completion:**
-    When a full round produces no actionable feedback (only nitpicks/won't-fix) AND this was already the "final verification" round:
+    When a full round (steps 1-6) produces no actionable feedback AND this was the "final verification" round:
     - Report all beads tickets created during the review loop (if any)
     - Ask user about merge
 
-    Critical rules:
+    **Critical rules:**
+    - ⚠️ Complete ALL steps 1-6 before step 7-8. Never skip to triggering another review.
     - ALWAYS use commit-and-push.sh, NEVER git commit/push
     - For LINE comments (Gemini, agents): reply using reply-to-comment.sh
-    - For PR comments (Claude): reply using gh pr comment with consolidated response
-    - ALWAYS use --wait flags when polling for reviews (5min timeout)
+    - For PR comments (Claude, IC_...): reply using reply-to-comment.sh (it handles both types)
     - Be skeptical of review suggestions - not all should be implemented
-    - For good suggestions out of scope: create beads ticket if `bd --version` succeeds
-    - Track created beads tickets to report at completion
-    - Track state with TodoWrite (loop state + per-agent state)
+    - Track state with TodoWrite (current step, loop round, per-agent state)
     - Spawn agent reviewers in PARALLEL (multiple Task calls in one message)
 ```
 
@@ -208,11 +214,34 @@ Track review rounds. After 2-3 iterations, evaluate:
 
 ### The Loop
 
-Each round includes all reviewers before triggering the next cycle:
+**⚠️ CRITICAL: Each round includes ALL reviewer types before triggering the next cycle.**
+
+**DO NOT** run multiple Gemini rounds before checking other reviewers. After addressing Gemini comments, you MUST check for other bot comments and run agent reviewers BEFORE triggering another Gemini review. This interleaving is essential because:
+- Fixes made for Gemini may resolve issues other reviewers would have flagged
+- Running all Gemini rounds first makes other reviewer feedback stale and irrelevant
 
 ```
-EACH ROUND:
-1. Get unresolved Gemini LINE comments (use --wait to poll for up to 5 minutes)
+EACH ROUND (all steps before next review trigger):
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Get Gemini comments (--wait only on first check)         │
+│ 2. Address ALL Gemini comments                              │
+│ 3. Check for other bot PR comments (Claude, Cursor, etc.)   │
+│ 4. Address ALL other bot comments                           │
+│ 5. Run agent reviewers (AGENT-REVIEWERS.md)                 │
+│ 6. Address ALL agent comments                               │
+│ 7. Commit and push (if ANY fixes were made in steps 2,4,6)  │
+│ 8. Trigger next review (--wait)                             │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                    Go to step 1 (next round)
+```
+
+**Step details:**
+
+1. Get unresolved Gemini LINE comments:
+   - First round after PR creation/push: use `--wait` to poll up to 5 minutes
+   - Subsequent rounds: `--wait` is already triggered by step 8
 2. Address Gemini line comments:
    - Fix it → reply "Fixed - ..."
    - Bad suggestion → reply "Won't fix - ..."
@@ -220,22 +249,23 @@ EACH ROUND:
 3. Check for other bot PR comments (Claude, Cursor, Copilot):
    - These are single PR comments containing multiple issues
    - Parse the structured markdown to extract individual issues
+4. Address other bot comments:
    - Reply to the PR comment addressing each issue (see "Comment Formats" section)
-4. Run agent reviewers (if AGENT-REVIEWERS.md exists and agents not retired):
+5. Run agent reviewers (if AGENT-REVIEWERS.md exists and agents not retired):
    - Spawn non-retired agents as parallel Tasks
    - Wait for all agents to return
-   - Address agent comments (fix/wontfix/out-of-scope flow)
+6. Address agent comments:
+   - Same fix/wontfix/out-of-scope flow as Gemini
    - Track per-agent diminishing returns, retire unproductive agents
-5. Use commit-and-push.sh (NEVER raw git commands) - if any fixes were made
-6. Trigger next review: trigger-review.sh <PR> --wait
-7. Go to step 1
+7. Commit and push (NEVER raw git commands) - if ANY fixes were made in this round
+8. Trigger next review: `trigger-review.sh <PR> --wait`
+9. Go to step 1
 
-COMPLETION:
+**COMPLETION:**
 When a full round produces no actionable feedback (Gemini + other bots + agents all stable)
 AND this was the "final verification" round:
-8. Report all beads tickets created during the loop (if any)
-9. Ask user about merge
-```
+- Report all beads tickets created during the loop (if any)
+- Ask user about merge
 
 ### Step-by-step (Each Round)
 

--- a/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
+++ b/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
@@ -72,7 +72,7 @@ Task tool:
        - Parse the structured markdown to extract individual issues
 
     4. **Address ALL other bot comments**:
-       - Reply with `gh pr comment` addressing each issue
+       - Reply using `reply-to-comment.sh <PR> <comment-id> "response"` (handles PR comments)
 
     5. **Run agent reviewers** (if AGENT-REVIEWERS.md exists and agents not retired):
        - Spawn non-retired agents as parallel Tasks (multiple Task calls in ONE message)
@@ -250,7 +250,7 @@ EACH ROUND (all steps before next review trigger):
    - These are single PR comments containing multiple issues
    - Parse the structured markdown to extract individual issues
 4. Address other bot comments:
-   - Reply to the PR comment addressing each issue (see "Comment Formats" section)
+   - Reply using `reply-to-comment.sh <PR> <comment-id> "response"` (handles PR comments)
 5. Run agent reviewers (if AGENT-REVIEWERS.md exists and agents not retired):
    - Spawn non-retired agents as parallel Tasks
    - Wait for all agents to return

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/reply-to-comment.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/reply-to-comment.sh
@@ -3,7 +3,10 @@
 # Usage: reply-to-comment.sh <pr-number> <comment-id> "reply message" [--no-resolve]
 #
 # Comment IDs can be found in the output of get-review-comments.sh --with-ids
-# Accepts either numeric database ID or GraphQL Node ID (PRRC_...)
+# Accepts:
+#   - Numeric database ID for review comments
+#   - GraphQL Node ID for review comments (PRRC_...)
+#   - GraphQL Node ID for PR/issue comments (IC_...) - replies by quoting original
 # By default, resolves the conversation after replying. Use --no-resolve to skip.
 
 set -euo pipefail
@@ -20,110 +23,110 @@ REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
 
 echo "Replying to comment $COMMENT_ID on PR #$PR_NUMBER..."
 
-# Determine if this is a Node ID (starts with letters) or database ID (numeric)
-REPLY_POSTED=false
-if [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
-    # Numeric database ID - use REST API
-    REPLY_RESULT=$(gh api \
-        --method POST \
-        "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
-        -f body="$REPLY" 2>&1) && REPLY_POSTED=true || {
-        echo "Warning: Failed to post reply via REST API."
-        echo "Error: $REPLY_RESULT"
-    }
-else
-    # Node ID - use GraphQL
-    echo "Using GraphQL with Node ID..."
-fi
+# Check if this is a PR/issue comment (IC_...) vs a review comment (PRRC_... or numeric)
+# PR comments don't have threading, so we quote the original and post a new comment
+if [[ "$COMMENT_ID" =~ ^IC_ ]]; then
+    echo "Detected PR comment (issue comment). Will quote and reply..."
 
-# If REST API failed or we have a Node ID, try GraphQL
-if [[ "$REPLY_POSTED" == "false" ]]; then
-    # For GraphQL we need the PR's Node ID
-    PR_NODE_ID=$(gh api graphql -f query="
-        query(\$owner: String!, \$repo: String!, \$pr: Int!) {
-            repository(owner: \$owner, name: \$repo) {
-                pullRequest(number: \$pr) {
-                    id
-                }
-            }
-        }
-    " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
-    --jq '.data.repository.pullRequest.id' 2>/dev/null || echo "")
+    # Fetch the original comment to quote it
+    ORIGINAL_COMMENT=$(gh pr view "$PR_NUMBER" --json comments \
+        --jq ".comments[] | select(.id == \"$COMMENT_ID\") | {author: .author.login, body: .body}" 2>/dev/null || echo "")
 
-    if [[ -n "$PR_NODE_ID" ]]; then
-        # If we have a numeric ID but REST failed, convert to Node ID
-        NODE_ID="$COMMENT_ID"
-        if [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
-            # Look up the Node ID from the database ID (with pagination)
-            NODE_ID=""
-            CURSOR=""
-            HAS_NEXT=true
-            while [[ "$HAS_NEXT" == "true" ]] && [[ -z "$NODE_ID" ]]; do
-                if [[ -z "$CURSOR" ]]; then
-                    PAGE=$(gh api graphql -f query="
-                        query(\$owner: String!, \$repo: String!, \$pr: Int!) {
-                            repository(owner: \$owner, name: \$repo) {
-                                pullRequest(number: \$pr) {
-                                    reviewThreads(first: 100) {
-                                        pageInfo { hasNextPage endCursor }
-                                        nodes {
-                                            comments(first: 1) {
-                                                nodes { id databaseId }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" 2>/dev/null || echo "{}")
-                else
-                    PAGE=$(gh api graphql -f query="
-                        query(\$owner: String!, \$repo: String!, \$pr: Int!, \$cursor: String) {
-                            repository(owner: \$owner, name: \$repo) {
-                                pullRequest(number: \$pr) {
-                                    reviewThreads(first: 100, after: \$cursor) {
-                                        pageInfo { hasNextPage endCursor }
-                                        nodes {
-                                            comments(first: 1) {
-                                                nodes { id databaseId }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" -f cursor="$CURSOR" 2>/dev/null || echo "{}")
-                fi
-                NODE_ID=$(echo "$PAGE" | jq -r ".data.repository.pullRequest.reviewThreads.nodes[].comments.nodes[] | select(.databaseId == $COMMENT_ID) | .id" 2>/dev/null | head -1 || echo "")
-                HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
-                CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')
-            done
-        fi
-
-        if [[ -n "$NODE_ID" ]]; then
-            REPLY_RESULT=$(gh api graphql -f query='
-                mutation($body: String!, $commentId: ID!) {
-                    addPullRequestReviewComment(input: {
-                        inReplyTo: $commentId,
-                        body: $body
-                    }) {
-                        comment {
-                            id
-                        }
-                    }
-                }
-            ' -f body="$REPLY" -f commentId="$NODE_ID" 2>&1) && REPLY_POSTED=true || {
-                echo "Warning: GraphQL reply also failed."
-                echo "Error: $REPLY_RESULT"
-            }
-        fi
+    if [[ -z "$ORIGINAL_COMMENT" || "$ORIGINAL_COMMENT" == "null" ]]; then
+        echo "ERROR: Could not find PR comment with ID: $COMMENT_ID" >&2
+        echo "The comment may have been deleted or the ID is invalid." >&2
+        echo "" >&2
+        echo "To debug, list all PR comments with:" >&2
+        echo "  gh pr view $PR_NUMBER --json comments --jq '.comments[].id'" >&2
+        exit 1
     fi
+
+    ORIGINAL_AUTHOR=$(echo "$ORIGINAL_COMMENT" | jq -r '.author')
+    ORIGINAL_BODY=$(echo "$ORIGINAL_COMMENT" | jq -r '.body')
+
+    # Create a quoted reply - take first 500 chars of original to keep it reasonable
+    QUOTED_BODY=$(echo "$ORIGINAL_BODY" | head -c 500)
+    if [[ ${#ORIGINAL_BODY} -gt 500 ]]; then
+        QUOTED_BODY="${QUOTED_BODY}..."
+    fi
+
+    # Format the reply with quote
+    REPLY_BODY=$(cat <<EOF
+> **@${ORIGINAL_AUTHOR}** wrote:
+$(echo "$QUOTED_BODY" | sed 's/^/> /')
+
+$REPLY
+EOF
+)
+
+    # Post as a new PR comment
+    REPLY_RESULT=$(gh pr comment "$PR_NUMBER" --body "$REPLY_BODY" 2>&1) && {
+        echo "Reply posted successfully (as new PR comment with quote)."
+        exit 0
+    } || {
+        echo "ERROR: Failed to post PR comment." >&2
+        echo "API Response: $REPLY_RESULT" >&2
+        exit 1
+    }
 fi
+
+# For review comments: we need the numeric database ID for the REST API
+# GraphQL's addPullRequestReviewComment mutation is for pending reviews only,
+# not for replying to existing comments. REST API is the only way to reply.
+DATABASE_ID="$COMMENT_ID"
+
+# If given a Node ID (PRRC_...), look up the database ID via REST API
+if [[ ! "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
+    echo "Converting Node ID to database ID..."
+
+    # Fetch all comments and find the one with matching node_id
+    DATABASE_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate \
+        --jq ".[] | select(.node_id == \"$COMMENT_ID\") | .id" 2>/dev/null | head -1 || echo "")
+
+    if [[ -z "$DATABASE_ID" ]]; then
+        echo "ERROR: Could not find review comment with Node ID: $COMMENT_ID" >&2
+        echo "The comment may have been deleted or the Node ID is invalid." >&2
+        echo "" >&2
+        echo "To debug, list all review comments with:" >&2
+        echo "  gh api repos/$REPO/pulls/$PR_NUMBER/comments --jq '.[].node_id'" >&2
+        exit 1
+    fi
+
+    echo "Found database ID: $DATABASE_ID"
+fi
+
+# Post reply using REST API (the only way to reply to existing review comments)
+REPLY_POSTED=false
+REPLY_RESULT=$(gh api \
+    --method POST \
+    "repos/$REPO/pulls/$PR_NUMBER/comments/$DATABASE_ID/replies" \
+    -f body="$REPLY" 2>&1) && REPLY_POSTED=true || {
+    echo "ERROR: Failed to post reply via REST API." >&2
+    echo "" >&2
+    echo "API Response: $REPLY_RESULT" >&2
+    echo "" >&2
+    # Parse common errors
+    if echo "$REPLY_RESULT" | grep -q "Not Found"; then
+        echo "Possible causes:" >&2
+        echo "  - Comment ID $DATABASE_ID does not exist on PR #$PR_NUMBER" >&2
+        echo "  - The comment may have been deleted" >&2
+        echo "  - You may not have access to this repository" >&2
+    elif echo "$REPLY_RESULT" | grep -q "Forbidden"; then
+        echo "Possible causes:" >&2
+        echo "  - You don't have permission to comment on this PR" >&2
+        echo "  - Your GitHub token may be missing 'repo' scope" >&2
+        echo "  - Check token permissions: gh auth status" >&2
+    elif echo "$REPLY_RESULT" | grep -q "Validation Failed"; then
+        echo "Possible causes:" >&2
+        echo "  - The reply body may be empty or invalid" >&2
+        echo "  - The comment thread may be locked" >&2
+    fi
+}
 
 if [[ "$REPLY_POSTED" == "true" ]]; then
-    echo "Reply posted."
+    echo "Reply posted successfully."
 else
-    echo "Warning: Could not post reply. Thread will still be resolved."
+    echo "Warning: Could not post reply. Will still attempt to resolve thread."
 fi
 
 # Resolve the thread unless --no-resolve is specified
@@ -131,6 +134,7 @@ if [[ "$NO_RESOLVE" != "--no-resolve" ]]; then
     echo "Resolving thread..."
 
     # Get thread ID by finding the thread that contains this comment (with pagination)
+    # Use DATABASE_ID which we resolved earlier (handles both numeric and Node ID inputs)
     THREAD_ID=""
     CURSOR=""
     HAS_NEXT=true
@@ -152,7 +156,10 @@ if [[ "$NO_RESOLVE" != "--no-resolve" ]]; then
                         }
                     }
                 }
-            " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" 2>/dev/null || echo "{}")
+            " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" 2>&1) || {
+                echo "Warning: GraphQL query failed: $PAGE" >&2
+                break
+            }
         else
             PAGE=$(gh api graphql -f query="
                 query(\$owner: String!, \$repo: String!, \$pr: Int!, \$cursor: String) {
@@ -170,15 +177,18 @@ if [[ "$NO_RESOLVE" != "--no-resolve" ]]; then
                         }
                     }
                 }
-            " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" -f cursor="$CURSOR" 2>/dev/null || echo "{}")
+            " -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" -f cursor="$CURSOR" 2>&1) || {
+                echo "Warning: GraphQL query failed: $PAGE" >&2
+                break
+            }
         fi
-        THREAD_ID=$(echo "$PAGE" | jq -r ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == $COMMENT_ID) | .id" 2>/dev/null | head -1 || echo "")
-        HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')
-        CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')
+        THREAD_ID=$(echo "$PAGE" | jq -r ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == $DATABASE_ID) | .id" 2>/dev/null | head -1 || echo "")
+        HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null || echo "false")
+        CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' 2>/dev/null || echo "")
     done
 
     if [[ -n "$THREAD_ID" && "$THREAD_ID" != "null" ]]; then
-        gh api graphql -f query="
+        RESOLVE_RESULT=$(gh api graphql -f query="
             mutation(\$threadId: ID!) {
                 resolveReviewThread(input: {threadId: \$threadId}) {
                     thread {
@@ -186,8 +196,15 @@ if [[ "$NO_RESOLVE" != "--no-resolve" ]]; then
                     }
                 }
             }
-        " -f threadId="$THREAD_ID" > /dev/null 2>&1 && echo "Thread resolved." || echo "Warning: Could not resolve thread."
+        " -f threadId="$THREAD_ID" 2>&1) && echo "Thread resolved." || {
+            echo "Warning: Could not resolve thread." >&2
+            echo "GraphQL response: $RESOLVE_RESULT" >&2
+        }
     else
-        echo "Warning: Could not find thread ID to resolve."
+        echo "Warning: Could not find thread ID to resolve." >&2
+        echo "This may happen if:" >&2
+        echo "  - The comment is not part of a review thread (e.g., a PR comment)" >&2
+        echo "  - The thread was already resolved" >&2
+        echo "  - The comment ID $DATABASE_ID doesn't match any thread" >&2
     fi
 fi

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/reply-to-comment.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/reply-to-comment.sh
@@ -45,7 +45,8 @@ if [[ "$COMMENT_ID" =~ ^IC_ ]]; then
     ORIGINAL_BODY=$(echo "$ORIGINAL_COMMENT" | jq -r '.body')
 
     # Create a quoted reply - take first 500 chars of original to keep it reasonable
-    QUOTED_BODY=$(echo "$ORIGINAL_BODY" | head -c 500)
+    # Use printf instead of echo to safely handle strings that might start with -
+    QUOTED_BODY=$(printf "%s" "$ORIGINAL_BODY" | head -c 500)
     if [[ ${#ORIGINAL_BODY} -gt 500 ]]; then
         QUOTED_BODY="${QUOTED_BODY}..."
     fi
@@ -53,7 +54,7 @@ if [[ "$COMMENT_ID" =~ ^IC_ ]]; then
     # Format the reply with quote
     REPLY_BODY=$(cat <<EOF
 > **@${ORIGINAL_AUTHOR}** wrote:
-$(echo "$QUOTED_BODY" | sed 's/^/> /')
+$(printf "%s" "$QUOTED_BODY" | sed 's/^/> /')
 
 $REPLY
 EOF


### PR DESCRIPTION
## Summary
- Fix `reply-to-comment.sh` to properly handle Node IDs (PRRC_...) and PR comments (IC_...)
- Clarify that the review loop must be interleaved (all reviewer types per round, not sequential)

## Changes

### reply-to-comment.sh
- When given a Node ID (PRRC_...), convert to database ID via REST API
- GraphQL `addPullRequestReviewComment` only works for pending reviews, not replies - removed broken code path
- Add support for PR comments (IC_...) by quoting original and posting new comment
- Improve error messages with specific troubleshooting guidance
- Fix thread resolution to use resolved DATABASE_ID

### SKILL.md
- Add prominent warning that each round must include ALL reviewer types
- Add visual diagram showing the interleaved flow
- Emphasize: do NOT run multiple Gemini rounds before checking other reviewers
- Update recommended Task prompt with clearer step numbering

## Test plan
- [x] Test reply to Gemini review comment with Node ID (PRRC_...) - works
- [x] Test reply to dependency-reviewer comment with Node ID - works
- [x] Test reply to PR comment (IC_...) - quotes original and posts new comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)