### PR TITLE
feat(pr-review-loop): add discover-agents.sh for hierarchical AGENT-REVIEWERS.md discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "pr-review-loop",
       "description": "Autonomous PR review automation with multi-bot support (Gemini, Cursor, Claude)",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "source": "./plugins/pr-review-loop",
       "category": "productivity",
       "author": {

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5e0e0a5b-ab12-41f3-b867-41003991de94","pid":413911,"procStart":"75615053","acquiredAt":1777048584778}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5e0e0a5b-ab12-41f3-b867-41003991de94","pid":413911,"procStart":"75615053","acquiredAt":1777048584778}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+# Claude Code local state (per-machine, must not be committed)
+.claude/

--- a/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
+++ b/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
@@ -568,13 +568,13 @@ Authentication uses JWT tokens stored in httpOnly cookies.
 
 Agent reviewers run as part of **each review round**, after addressing Gemini and other bot comments.
 
-On the first round (or when new agents are discovered), discover agent reviewers using the discovery script:
+On the first round (or when new agents are discovered), discover agent reviewers:
 
 ```bash
 scripts/discover-agents.sh <PR>
 ```
 
-Each agent's `changed_files` list contains only the PR's changed files within that agent's scope. Pass this list to the agent so it reviews only relevant files.
+Each agent's `changed_files` list contains only the PR's changed files within that agent's scope. Pass this list to the agent.
 
 Spawn non-retired agents **in parallel** at step 4 of each round. Track per-agent state to avoid re-running retired agents.
 
@@ -705,7 +705,7 @@ When detected, the script suggests:
 | `post-line-comment.sh <PR> <file> <line> <agent> "msg"` | Post line comment with agent signature |
 | `get-agent-comments.sh <PR> <agent> [--with-replies]` | Fetch agent's own comments and replies |
 | `reopen-comment.sh <PR> <comment-id> <agent> "reason"` | Reply to resolved thread with Claude attribution |
-| `discover-agents.sh <PR>` | Discover AGENT-REVIEWERS.md files with hierarchical scoping, returns JSON |
+| `discover-agents.sh <PR>` | Discover agent reviewers with hierarchical scoping |
 
 ## Permission Setup
 

--- a/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
+++ b/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
@@ -557,26 +557,24 @@ Authentication uses JWT tokens stored in httpOnly cookies.
 - For `plugins/auth/login.py`: combines `# Guidelines` from `/plugins/` + `# Context` from `/plugins/auth/`
 - For `plugins/utils.py`: uses `# Guidelines` from `/plugins/`
 
-**Discovery algorithm:**
-```bash
-# For each unique directory containing changed files:
-# 1. Walk up to repo root collecting AGENT-REVIEWERS.md paths
-# 2. Parse each file, building agent map (lower wins on name collision)
-# 3. Track each agent's scope (directory where it was defined)
-```
+**Discovery algorithm** (implemented by `scripts/discover-agents.sh`):
+1. Get changed files via `gh pr diff <PR> --name-only`
+2. For each unique directory containing changed files, walk up to repo root collecting `AGENT-REVIEWERS.md` paths
+3. Parse each file, building agent map (lower directory wins on name collision)
+4. Track each agent's scope (directory where it was defined)
+5. Filter changed files per agent to only those within the agent's scope
 
 ### When to Run Agent Reviewers
 
 Agent reviewers run as part of **each review round**, after addressing Gemini and other bot comments.
 
-On the first round (or when new agents are discovered), discover agent reviewers:
+On the first round (or when new agents are discovered), discover agent reviewers using the discovery script:
 
 ```bash
-# Get list of changed files
-gh pr diff <PR> --name-only
-
-# For each unique parent directory, check for AGENT-REVIEWERS.md up to repo root
+scripts/discover-agents.sh <PR>
 ```
+
+Each agent's `changed_files` list contains only the PR's changed files within that agent's scope. Pass this list to the agent so it reviews only relevant files.
 
 Spawn non-retired agents **in parallel** at step 4 of each round. Track per-agent state to avoid re-running retired agents.
 
@@ -595,7 +593,10 @@ Task tool:
     Your focus: <instructions from AGENT-REVIEWERS.md>
 
     **Your scope: <scope-path>/**
-    You should ONLY review changes to files under this path. Ignore changes outside your scope.
+    You should ONLY review changes to the files listed below. Ignore all other files.
+
+    **Changed files in your scope:**
+    <changed_files list from discover-agents.sh output>
 
     ## Your workflow:
 
@@ -611,11 +612,11 @@ Task tool:
          scripts/reopen-comment.sh <PR> <comment-id> <agent-name> "Reopening - <reason why response is insufficient>"
          ```
 
-    3. **Review the PR diff** (filter to your scope):
+    3. **Review the PR diff** (only your changed_files):
+       Read each file from your changed_files list directly, or filter the diff:
        ```bash
-       gh pr diff <PR> -- '<scope-path>/*'
+       gh pr diff <PR> -- <file1> <file2> ...
        ```
-       If scope is repo root, use `gh pr diff <PR>` without path filter.
 
     4. **Post NEW findings** as line comments (only issues not already raised, only files in your scope):
        ```bash
@@ -704,6 +705,7 @@ When detected, the script suggests:
 | `post-line-comment.sh <PR> <file> <line> <agent> "msg"` | Post line comment with agent signature |
 | `get-agent-comments.sh <PR> <agent> [--with-replies]` | Fetch agent's own comments and replies |
 | `reopen-comment.sh <PR> <comment-id> <agent> "reason"` | Reply to resolved thread with Claude attribution |
+| `discover-agents.sh <PR>` | Discover AGENT-REVIEWERS.md files with hierarchical scoping, returns JSON |
 
 ## Permission Setup
 
@@ -716,6 +718,7 @@ Bash(scripts/check-ci.sh:*)
 Bash(scripts/post-line-comment.sh:*)
 Bash(scripts/get-agent-comments.sh:*)
 Bash(scripts/reopen-comment.sh:*)
+Bash(scripts/discover-agents.sh:*)
 ```
 
 ## Prerequisites

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/discover-agents.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/discover-agents.sh
@@ -26,8 +26,10 @@ PR_NUMBER="${1:?Usage: discover-agents.sh <pr-number>}"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Get changed files in the PR
-CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
+# Get changed files in the PR. Let gh errors propagate (set -e) so a missing
+# gh, unauthenticated user, or bad PR number fails loudly instead of silently
+# returning an empty agent list.
+CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only)
 
 if [[ -z "$CHANGED_FILES" ]]; then
     echo '{"agents":[],"context":[]}'

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/discover-agents.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/discover-agents.sh
@@ -149,18 +149,13 @@ parse_agent_file() {
     ' "$file"
 }
 
-# Collect all parsed sections from all files
-ALL_SECTIONS=""
-for file in "${AGENT_FILES[@]}"; do
-    parsed="$(parse_agent_file "$file")"
-    if [[ -n "$parsed" ]]; then
-        if [[ -n "$ALL_SECTIONS" ]]; then
-            ALL_SECTIONS="$ALL_SECTIONS"$'\n'"$parsed"
-        else
-            ALL_SECTIONS="$parsed"
-        fi
-    fi
-done
+# Collect all parsed sections from all files. Capturing the loop's output
+# with command substitution is O(n) vs repeated string concatenation (O(n²)).
+ALL_SECTIONS=$(
+    for file in "${AGENT_FILES[@]}"; do
+        parse_agent_file "$file"
+    done
+)
 
 if [[ -z "$ALL_SECTIONS" ]]; then
     echo '{"agents":[],"context":[]}'
@@ -173,7 +168,7 @@ fi
 # Build a JSON array of changed files for scoping
 CHANGED_FILES_JSON=$(jq -n --arg files "$CHANGED_FILES" '$files | split("\n") | map(select(. != ""))')
 
-echo "$ALL_SECTIONS" | jq -s --argjson files "$CHANGED_FILES_JSON" '
+printf '%s\n' "$ALL_SECTIONS" | jq -s --argjson files "$CHANGED_FILES_JSON" '
     {
         agents: (
             [.[] | select(.type == "agent")] |

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/discover-agents.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/discover-agents.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Discover AGENT-REVIEWERS.md files for all changed files in a PR.
+# Walks up from each changed file's directory to repo root, collecting
+# agent definitions with hierarchical scoping (lower directories override).
+#
+# Usage: discover-agents.sh <pr-number>
+#
+# Output: JSON array of agents with name, scope, instructions, and source file.
+# Also outputs context sections (non-Agents H1 sections) per scope.
+#
+# Example output:
+# {
+#   "agents": [
+#     {"name": "security-reviewer", "scope": "/", "source": "/AGENT-REVIEWERS.md", "instructions": "..."},
+#     {"name": "sql-injection-reviewer", "scope": "/services/api/", "source": "/services/api/AGENT-REVIEWERS.md", "instructions": "..."}
+#   ],
+#   "context": [
+#     {"scope": "/", "section": "Guidelines", "content": "..."},
+#     {"scope": "/services/api/", "section": "Guidelines", "content": "..."}
+#   ]
+# }
+
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: discover-agents.sh <pr-number>}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Get changed files in the PR
+CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
+
+if [[ -z "$CHANGED_FILES" ]]; then
+    echo '{"agents":[],"context":[]}'
+    exit 0
+fi
+
+# Collect unique directories containing changed files
+DIRS=()
+while IFS= read -r file; do
+    dir="$(dirname "$file")"
+    DIRS+=("$dir")
+done <<< "$CHANGED_FILES"
+
+# Deduplicate directories
+UNIQUE_DIRS=()
+while IFS= read -r d; do
+    [[ -n "$d" ]] && UNIQUE_DIRS+=("$d")
+done < <(printf '%s\n' "${DIRS[@]}" | sort -u)
+
+# For each directory, walk up to repo root collecting AGENT-REVIEWERS.md paths
+AGENT_FILES=()
+SEEN_AGENT_FILES="|"
+
+_seen() { [[ "$SEEN_AGENT_FILES" == *"|$1|"* ]]; }
+_mark() { SEEN_AGENT_FILES="${SEEN_AGENT_FILES}$1|"; }
+
+for dir in "${UNIQUE_DIRS[@]}"; do
+    current="$dir"
+    while true; do
+        agent_file="$REPO_ROOT/$current/AGENT-REVIEWERS.md"
+        if [[ -f "$agent_file" ]] && ! _seen "$agent_file"; then
+            AGENT_FILES+=("$agent_file")
+            _mark "$agent_file"
+        fi
+
+        # Move up one directory
+        if [[ "$current" == "." ]]; then
+            break
+        fi
+        current="$(dirname "$current")"
+    done
+done
+
+if [[ ${#AGENT_FILES[@]} -eq 0 ]]; then
+    echo '{"agents":[],"context":[]}'
+    exit 0
+fi
+
+# Parse each AGENT-REVIEWERS.md file and extract agents + context sections.
+# Uses awk to split on H1/H2 headings and classify sections.
+#
+# Output per file: JSON lines with type (agent|context), name, scope, content, source
+parse_agent_file() {
+    local file="$1"
+    local rel_path="${file#$REPO_ROOT/}"
+    local scope_dir
+    scope_dir="$(dirname "$rel_path")"
+    if [[ "$scope_dir" == "." ]]; then
+        scope_dir="/"
+    else
+        scope_dir="/$scope_dir/"
+    fi
+
+    awk -v scope="$scope_dir" -v source="$rel_path" '
+    function json_escape(s) {
+        gsub(/\\/, "&&", s)
+        gsub(/"/, "\\\"", s)
+        gsub(/\n/, "\\n", s)
+        gsub(/\r/, "\\r", s)
+        gsub(/\t/, "\\t", s)
+        return s
+    }
+
+    function flush() {
+        if (current_h2 != "" && content != "") {
+            printf "{\"type\":\"agent\",\"name\":\"%s\",\"scope\":\"%s\",\"source\":\"%s\",\"instructions\":\"%s\"}\n", json_escape(current_h2), json_escape(scope), json_escape(source), json_escape(content)
+            current_h2 = ""
+            content = ""
+        } else if (current_h1 != "" && current_h1 != "Agents" && content != "") {
+            printf "{\"type\":\"context\",\"section\":\"%s\",\"scope\":\"%s\",\"source\":\"%s\",\"content\":\"%s\"}\n", json_escape(current_h1), json_escape(scope), json_escape(source), json_escape(content)
+            content = ""
+        }
+    }
+
+    BEGIN {
+        in_agents = 0
+        current_h2 = ""
+        current_h1 = ""
+        content = ""
+    }
+
+    /^# / {
+        flush()
+        h1_name = substr($0, 3)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", h1_name)
+        current_h1 = h1_name
+        in_agents = (h1_name == "Agents")
+        current_h2 = ""
+        content = ""
+        next
+    }
+
+    /^## / && in_agents {
+        flush()
+        current_h2 = substr($0, 4)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", current_h2)
+        content = ""
+        next
+    }
+
+    {
+        if (content != "") content = content "\n" $0
+        else content = $0
+    }
+
+    END {
+        flush()
+    }
+    ' "$file"
+}
+
+# Collect all parsed sections from all files
+ALL_SECTIONS=""
+for file in "${AGENT_FILES[@]}"; do
+    parsed="$(parse_agent_file "$file")"
+    if [[ -n "$parsed" ]]; then
+        if [[ -n "$ALL_SECTIONS" ]]; then
+            ALL_SECTIONS="$ALL_SECTIONS"$'\n'"$parsed"
+        else
+            ALL_SECTIONS="$parsed"
+        fi
+    fi
+done
+
+if [[ -z "$ALL_SECTIONS" ]]; then
+    echo '{"agents":[],"context":[]}'
+    exit 0
+fi
+
+# Merge agents: lower scope (more specific path) wins on name collision.
+# Sort by scope depth (deeper first), then deduplicate by name keeping first.
+# Collect context sections (no dedup needed — all are passed through).
+# Build a JSON array of changed files for scoping
+CHANGED_FILES_JSON=$(jq -n --arg files "$CHANGED_FILES" '$files | split("\n") | map(select(. != ""))')
+
+echo "$ALL_SECTIONS" | jq -s --argjson files "$CHANGED_FILES_JSON" '
+    {
+        agents: (
+            [.[] | select(.type == "agent")] |
+            # Sort by scope depth descending (deeper = more specific = wins)
+            sort_by(.scope | split("/") | length) | reverse |
+            # Deduplicate by name (first occurrence wins = deepest scope)
+            reduce .[] as $agent (
+                {seen: {}, result: []};
+                if .seen[$agent.name] then .
+                else .seen[$agent.name] = true | .result += [$agent]
+                end
+            ) | .result |
+            map({name, scope, source, instructions,
+                changed_files: (
+                    .scope as $s |
+                    if $s == "/" then $files
+                    else [$files[] | select(startswith($s | ltrimstr("/")))]
+                    end
+                )
+            })
+        ),
+        context: (
+            [.[] | select(.type == "context")] |
+            sort_by(.scope | split("/") | length) | reverse |
+            reduce .[] as $ctx (
+                {seen: {}, result: []};
+                if .seen[$ctx.section] then .
+                else .seen[$ctx.section] = true | .result += [$ctx]
+                end
+            ) | .result |
+            map({section, scope, source, content})
+        )
+    }
+'


### PR DESCRIPTION
## Summary

- New `scripts/discover-agents.sh` that deterministically discovers `AGENT-REVIEWERS.md` files across a directory hierarchy.
- Walks up from each changed file's directory to repo root, parses agent and context sections via awk, and returns JSON with per-agent scope and a filtered `changed_files` list.
- Deeper directories override same-named agents from parents; each agent's `changed_files` is filtered to files within its scope.
- Updated `SKILL.md` to reference the script in the discovery, spawning, and permissions sections. Agent spawning template now includes the scoped `changed_files` list so agents review only relevant files.

Previously, agent discovery relied on Claude following prose instructions to manually walk directories — unreliable and untestable. The script makes it deterministic.

Closes devon-claude-skills-z3r.

## Test plan

- [x] Script executes cleanly against a PR in this repo (smoke-tested locally on PR #6)
- [x] Scope filtering: `/` scope returns all changed files; non-root scope returns subset matching `startswith(scope)`
- [ ] Test against a repo with no AGENT-REVIEWERS.md (should return `{"agents":[],"context":[]}`)
- [ ] Test against a hierarchy with same-named agents at multiple depths (deeper wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)