### PR TITLE
feat(pr-review-loop): port review-loop enhancements from upstream fork

### DIFF
--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -7,6 +7,10 @@ This is a Claude Code skills marketplace repository. When reviewing PRs:
 - Error messages must go to stderr (`>&2`)
 - Scripts should handle both success and failure cases gracefully
 - New dependencies require installation instructions in SKILL.md
+- SKILL.md and `references/*.md` files are **agent instruction documents**, not traditional code — evaluate for agent clarity and accuracy
+- Before asserting a factual claim is wrong (software version, API endpoint), verify it — training data may be stale
+- Check prior review comments and responses before re-raising the same issue — if a "Won't fix" response has sound reasoning, do not repeat the concern
+- If a `.beads/` directory exists, check its contents before flagging pre-existing issues as immediate demands
 
 # Agents
 
@@ -30,6 +34,7 @@ You are a reviewer ensuring new skills are properly registered in the marketplac
 
 **Flag issues if:**
 - A new skill directory exists but has no entry in marketplace.json
+- A new skill directory has no `SKILL.md` file (incomplete/stub skill)
 - An existing skill was renamed but marketplace.json wasn't updated
 - Required fields are missing or clearly wrong (e.g., description is empty)
 - The `source` path doesn't match the actual plugin location
@@ -75,6 +80,34 @@ You are a reviewer ensuring new dependencies have proper installation instructio
 - Where the installation instructions should be added (usually SKILL.md Prerequisites)
 - What the instructions should say (package manager command, link to docs, etc.)
 
+## shell-script-reviewer
+
+You are a reviewer ensuring shell scripts meet repository standards.
+
+**Your focus:** Shell script quality and correctness for any new or modified `.sh` files.
+
+**What to check:**
+
+1. Look at the PR diff for new or modified `.sh` files
+2. For each script, verify:
+   - Starts with `set -euo pipefail`
+   - Error and warning messages go to stderr: `echo "Error: ..." >&2`
+   - Exit codes are meaningful: non-zero on failure, zero on success
+   - Variables that could contain spaces or special characters are quoted where word-splitting or globbing could occur
+
+**Flag issues if:**
+- A **newly added** script is missing `set -euo pipefail` — flag as a defect
+- A **modified existing** script is missing `set -euo pipefail` — flag as a pre-existing gap to address in a follow-up PR, not a blocker for this PR
+- Error messages in new or modified code go to stdout instead of stderr
+- New or modified code exits zero when it should indicate failure
+
+**Do NOT flag:**
+- Comment style or formatting preferences
+- Intentional stdout output (script results, data output — not error messages)
+- Environment-specific conventions that are documented as intentional
+- Scripts with no changes in this PR
+- Pre-existing issues in unchanged lines of a modified script
+
 ## clarity-reviewer
 
 You are a reviewer ensuring markdown documentation is terse yet complete.
@@ -117,6 +150,7 @@ You are a reviewer ensuring markdown documentation is terse yet complete.
 - Examples and code blocks (these should be complete)
 - Repetition that serves as a deliberate reminder (e.g., "NEVER use git push" repeated for emphasis)
 - Technical precision that requires specific wording
+- Deliberate repetition of key rules in SKILL.md and `references/*.md` files — these are agent instruction documents where repeating critical constraints is intentional emphasis, not redundancy
 
 **When flagging, provide:**
 - The verbose text

--- a/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
+++ b/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
@@ -147,22 +147,99 @@ The key difference: Claude comments don't have "threads" to resolve - you reply 
 
 When in doubt, ask the user rather than blindly applying changes.
 
-## Diminishing Returns Detection
+### Self-Contradiction Detection
 
-Track review rounds. After 2-3 iterations, evaluate:
-- Are new comments addressing real issues or nitpicks?
-- Are we fixing the same type of issue repeatedly?
-- Are reviewers finding fewer/lower-priority issues?
+Track changes across rounds. When a fix in round N reverses or conflicts with a fix from a previous round, this signals that the review loop may be degrading the code rather than improving it.
 
-**ONE MORE LOOP rule**: When a full round (Gemini + other bots + agent reviewers) produces no actionable feedback (or only "Won't fix" responses), do ONE additional round to catch any final feedback.
+**When a contradiction is detected:**
+
+1. **Identify all involved changes**: List the original code, the round N-K change, and the round N change that contradicts it.
+2. **Analyze both positions**: Each round may have had valid reasoning. Assess whether the later round caught a genuine mistake in the earlier fix, or whether the loop is oscillating.
+3. **Check against the original**: Compare both the round N-K and round N versions against the original pre-review-loop code. Often the original is the correct version.
+4. **Report to the user** with a clear summary: what changed, what contradicted it, your assessment of which version is correct and why, and a recommendation.
+5. **Do not silently apply the contradicting change.** Pause and get user input.
+
+**Parallel valid findings**: Multiple reviewers may independently flag different aspects of the same code. This is not a contradiction — it's convergent analysis. The key distinction is whether round N is *undoing* round N-K's work (contradiction) vs. addressing a *different concern* in nearby code (parallel findings).
+
+## Stopping Heuristics
+
+Use signal quality — not a fixed round cap — to decide when to stop iterating.
+
+### Per-Round Assessment
+
+After each round, evaluate:
+
+| Metric | What It Means |
+|--------|---------------|
+| **Fix/rejection ratio** | What fraction of comments led to actual code fixes vs. "Won't fix" responses? A declining ratio suggests diminishing returns. |
+| **Severity trend** | Are new comments addressing high-priority issues (correctness, security) or low-priority nitpicks (style, documentation)? |
+| **Contradiction count** | Has this round contradicted any previous round's fixes? If so, investigate before continuing. |
+| **Net code quality** | Is the code measurably better than after the previous round? Or are changes lateral (different but not better)? |
+
+### When to Continue
+
+- The current round produced fixes for genuine correctness or security issues
+- New comments are addressing aspects not previously reviewed
+- The fix/rejection ratio remains above ~50% (most comments are actionable)
+
+### When to Stop
+
+- Two consecutive rounds with mostly "Won't fix" or nitpick-only feedback
+- A self-contradiction is detected (pause for user input)
+- The fix/rejection ratio drops below ~25% (most comments are not actionable)
+- All remaining comments are stylistic or theoretical
+- Hard ceiling: 7 total rounds, or 5 consecutive nitpick-only rounds — stop regardless of other signals
+
+### ONE MORE LOOP Rule
+
+When a full round (Gemini + other bots + agent reviewers) produces no actionable feedback, do ONE additional "final verification" round to catch any last feedback from the final push.
 
 **Tracking state**: Use TodoWrite to track whether you're in the "final verification round". Create a todo like "Final verification round - if no actionable feedback, ready to merge".
 
-**Reset condition**: If the final verification round produces feedback you actually fix (not just "Won't fix"), remove the "final verification round" todo - you need a fresh "one more" after pushing those fixes.
+**Reset condition**: If the final verification round produces feedback you actually fix (not just "Won't fix"), remove the "final verification round" todo — you need a fresh "one more" after pushing those fixes.
 
-**Exit condition**: If the "final verification round" todo exists AND the round produces no actionable feedback (only nitpicks/won't-fix responses), you're done - ask about merge.
+**Exit condition**: If the "final verification round" todo exists AND the round produces no actionable feedback (only nitpicks/won't-fix responses), you're done — proceed to merge readiness checks.
 
-**After the final round**, ask the user: "We've completed the review cycles. Ready to merge, or want to address more?"
+## Merge Readiness
+
+When the review loop is complete (final verification round produced no actionable feedback), check CI status and read repo-specific merge guidance before proceeding.
+
+### 1. Check CI Status
+
+```bash
+gh pr checks <PR> --watch
+```
+
+Do not proceed to merge if any checks are still running or failing. If CI is still running or newly failing at this point, fall back to the [CI Fix Loop](#ci-failure-handling) to diagnose and fix before reporting readiness.
+
+### 2. Read Repo-Specific Merge Guidance
+
+Read the repo's `CLAUDE.md` and follow any linked files it references (e.g., `.ai-knowledge/code-review-guidelines.md`). These define the repo's merge policy — what approvals are required, whether auto-merge is permitted, attestation requirements, and any other merge criteria.
+
+Use whatever you find to determine:
+- Whether this PR is ready to merge or needs further action
+- Whether to merge automatically or ask the user
+- What information to include in a merge-readiness summary
+
+### 3. Prepare Merge-Readiness Summary
+
+Always prepare a summary of what the review loop did and observed. This is useful regardless of repo merge policy:
+
+- **Review loop activity**: Rounds completed, total comments addressed (fixed / won't fix / out of scope)
+- **CI status**: All checks passed, any failures, any checks still running
+- **Unresolved items**: Any review comments that remain open or contested
+- **Self-contradictions**: Any detected during the loop and how they were resolved
+- **Beads tickets**: Out-of-scope items captured for follow-up
+- **Branch protection status**: Whether all required checks and approvals are satisfied
+
+If repo-specific guidance defines additional merge criteria (attestation requirements, approval types, etc.), include the status of those criteria in the summary as well.
+
+### 4. Merge or Ask
+
+- **If repo guidance authorizes auto-merge** and all its criteria are met (CI passed, required approvals present, branch protections satisfied): merge
+- **If any criteria are not met**, or no repo-specific guidance exists: present the summary and ask the user
+
+The review loop should **not** override branch protections or bypass repo-defined merge requirements.
 
 ## Autonomous Loop Workflow
 
@@ -436,10 +513,17 @@ scripts/reply-to-comment.sh <PR> <comment-id> "Out of scope - tracked in BD-XXX"
 
 **Track the ticket** for reporting at the end of the review loop. Keep a list of all created tickets (ID and title) to include in the completion summary.
 
-**If beads is NOT installed**, just reply without creating a ticket:
-```bash
-scripts/reply-to-comment.sh <PR> <comment-id> "Out of scope for this PR"
-```
+**If beads is NOT installed:**
+
+1. Still reply to the comment noting the finding is out of scope:
+   ```bash
+   scripts/reply-to-comment.sh <PR> <comment-id> "Out of scope for this PR - see review loop completion summary"
+   ```
+2. Collect all out-of-scope findings with full context (original comment text, file paths, line numbers, PR number, reviewer, and the `gh api` command to fetch the comment). Store these in your TodoWrite state so they survive across rounds.
+3. In the completion summary, list all out-of-scope findings and recommend installing beads to track them. Offer to create a follow-up PR that:
+   - Creates a markdown file (e.g., `TODO-beads.md`) with pre-filled `bd create` commands for each out-of-scope finding, using the context collected in step 2
+   - Includes instructions for the user to run `bd init` and execute the commands in the markdown file
+4. If the user agrees, create a follow-up PR containing the generated markdown file and documentation updates explaining how users can install and use beads. This avoids requiring the agent to install and run beads itself.
 
 ## Triggering Reviews by Bot Type
 
@@ -447,7 +531,11 @@ scripts/reply-to-comment.sh <PR> <comment-id> "Out of scope for this PR"
 ```bash
 scripts/trigger-review.sh <PR> --gemini --wait
 ```
-Gemini has a daily quota. When exceeded, the skill automatically detects this and suggests alternatives.
+The script uses two checks to avoid redundant `/gemini review` triggers and conserve quota (33 reviews/day on free tier):
+1. **Commit check**: If Gemini has already reviewed the current HEAD commit, skips the trigger entirely.
+2. **Config check**: If `.gemini/config.yaml` exists with `code_review: true`, the repo has auto-review enabled. When `--wait` is used, the script waits one poll interval for an auto-review before falling back to a manual trigger.
+
+When quota is exceeded, the skill automatically detects this and suggests alternatives.
 
 ### Cursor Bugbot
 ```bash
@@ -679,6 +767,24 @@ As agents reach diminishing returns, stop calling them. The main loop should:
 
 This keeps the review loop efficient while ensuring all perspectives are heard at least once.
 
+## Suggesting AGENT-REVIEWERS.md Creation or Updates
+
+During the review loop, if you identify guidance that would improve review quality for the repo but isn't captured anywhere, suggest creating or updating an `AGENT-REVIEWERS.md` file.
+
+**When to suggest creating AGENT-REVIEWERS.md:**
+- The repo has no `AGENT-REVIEWERS.md` AND you identify specific guidance that would help — e.g., recurring review patterns, repo-specific conventions reviewers should know, or specialized review concerns (security, API compatibility) that warrant a custom agent reviewer.
+
+**When to suggest updating an existing AGENT-REVIEWERS.md:**
+- You notice review comments repeatedly flagging the same kind of issue that a `# Guidelines` entry could prevent.
+- A new area of the codebase (e.g., a new subdirectory with different conventions) would benefit from scoped agents or guidelines.
+- Existing agent definitions are missing context that would make their reviews more accurate.
+
+**What NOT to suggest:**
+- Don't suggest creating AGENT-REVIEWERS.md just because the file doesn't exist — only when you have concrete content that would go in it.
+- Don't duplicate guidance that already exists in CLAUDE.md or other repo documentation.
+
+**How to suggest it:** Present the recommendation to the user with the proposed content. Do not create or modify AGENT-REVIEWERS.md without user approval.
+
 ## Rate Limit Detection
 
 The scripts automatically detect Gemini quota limits by checking for:
@@ -694,7 +800,8 @@ When detected, the script suggests:
 |--------|---------|
 | `commit-and-push.sh "msg"` | **ALWAYS USE** - Never use raw git commit/push |
 | `reply-to-comment.sh <PR> <id> "msg"` | **ALWAYS USE** - Reply and auto-resolve every comment |
-| `get-review-comments.sh <PR> [--with-ids] [--wait]` | **USE --wait** - Fetch comments, polls 5min if --wait |
+| `get-review-comments.sh <PR> [--with-ids] [--wait]` | **USE --wait** - Fetch line comments (Gemini, Cursor), polls 5min if --wait |
+| `get-pr-comments.sh <PR> [--with-ids] [--wait] [--author]` | Fetch PR-level comments (Claude, Copilot) with priority detection |
 | `trigger-review.sh [PR] [--gemini\|--cursor\|--claude] [--wait]` | **USE --wait** - Trigger review and poll for response |
 | `check-ci.sh <PR> [--wait] [--timeout N]` | **USE --wait** - Wait for CI, report failures with logs |
 | `summarize-reviews.sh <PR> [--all]` | Summary of unresolved by priority/file |
@@ -719,6 +826,7 @@ Bash(scripts/post-line-comment.sh:*)
 Bash(scripts/get-agent-comments.sh:*)
 Bash(scripts/reopen-comment.sh:*)
 Bash(scripts/discover-agents.sh:*)
+Bash(scripts/get-pr-comments.sh:*)
 ```
 
 ## Prerequisites

--- a/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
+++ b/plugins/pr-review-loop/skills/pr-review-loop/SKILL.md
@@ -202,7 +202,7 @@ When a full round (Gemini + other bots + agent reviewers) produces no actionable
 
 ## Merge Readiness
 
-When the review loop is complete (final verification round produced no actionable feedback), check CI status and read repo-specific merge guidance before proceeding.
+When the review loop is complete, check CI status and read repo-specific merge guidance before proceeding.
 
 ### 1. Check CI Status
 
@@ -223,7 +223,7 @@ Use whatever you find to determine:
 
 ### 3. Prepare Merge-Readiness Summary
 
-Always prepare a summary of what the review loop did and observed. This is useful regardless of repo merge policy:
+Always prepare a summary of what the review loop did and observed:
 
 - **Review loop activity**: Rounds completed, total comments addressed (fixed / won't fix / out of scope)
 - **CI status**: All checks passed, any failures, any checks still running
@@ -523,7 +523,7 @@ scripts/reply-to-comment.sh <PR> <comment-id> "Out of scope - tracked in BD-XXX"
 3. In the completion summary, list all out-of-scope findings and recommend installing beads to track them. Offer to create a follow-up PR that:
    - Creates a markdown file (e.g., `TODO-beads.md`) with pre-filled `bd create` commands for each out-of-scope finding, using the context collected in step 2
    - Includes instructions for the user to run `bd init` and execute the commands in the markdown file
-4. If the user agrees, create a follow-up PR containing the generated markdown file and documentation updates explaining how users can install and use beads. This avoids requiring the agent to install and run beads itself.
+4. If the user agrees, create a follow-up PR containing the generated markdown file and documentation updates explaining how users can install and use beads.
 
 ## Triggering Reviews by Bot Type
 

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
@@ -44,8 +44,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Get repo info (needed for all gh calls to work from worktrees or when origin remote differs)
-REPO=$(git remote get-url origin 2>/dev/null | sed 's/.*github\.com[:\/]//' | sed 's/\.git$//')
+# Get repo info (needed for all gh calls to work from worktrees or when origin remote differs).
+# Let git's own error surface if we're not in a git repo or origin is missing.
+REPO=$(git remote get-url origin | sed 's/.*github\.com[:\/]//' | sed 's/\.git$//')
 
 # Validate PR number to fail fast on invalid input
 if ! gh pr view "$PR_NUMBER" -R "$REPO" --json number &> /dev/null; then

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
@@ -56,7 +56,12 @@ fi
 # Build jq select filter inline — gh pr view --jq does not support --arg/--argjson,
 # so the pattern is interpolated into the filter string by the shell.
 if [[ -n "$AUTHOR_FILTER" ]]; then
-    # Exact case-insensitive match on the author filter; lowercase in shell before inlining
+    # Validate author looks like a GitHub login (alphanumerics + hyphens, 1-39 chars, no leading/trailing hyphen).
+    # This prevents inlining unsafe characters into the jq filter string.
+    if [[ ! "$AUTHOR_FILTER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+        echo "Error: --author must be a valid GitHub login (alphanumerics and hyphens, 1-39 chars, no leading/trailing hyphen)." >&2
+        exit 2
+    fi
     LOWER_AUTHOR=$(printf '%s' "$AUTHOR_FILTER" | tr '[:upper:]' '[:lower:]')
     JQ_SELECT="select((.author.login | ascii_downcase) == \"$LOWER_AUTHOR\")"
 else
@@ -109,9 +114,12 @@ if [[ "$WAIT_FOR_COMMENTS" == "true" ]]; then
     fi
 fi
 
-# Fetch bot PR comments (let gh failures propagate via set -e)
-COMMENTS=$(gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
-    --jq "[.comments[] | $JQ_SELECT | {id: .id, author: .author.login, createdAt: .createdAt, body: .body}]")
+# Fetch bot PR comments
+if ! COMMENTS=$(gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
+    --jq "[.comments[] | $JQ_SELECT | {id: .id, author: .author.login, createdAt: .createdAt, body: .body}]"); then
+    echo "Error: Failed to fetch PR comments for #$PR_NUMBER." >&2
+    exit 1
+fi
 
 if [[ "$COMMENTS" == "[]" ]] || [[ -z "$COMMENTS" ]]; then
     echo "No PR comments found from bot reviewers."

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Get PR-level comments from bot reviewers (Claude, Cursor, Copilot, etc.)
+# Usage: get-pr-comments.sh <pr-number> [--with-ids] [--wait] [--author <login>]
+#
+# Unlike get-review-comments.sh (line comments via reviewThreads), this fetches
+# PR-level comments — single-comment reviews from bots like Claude.
+#
+# Options:
+#   --with-ids    Include comment IDs for use with reply-to-comment.sh
+#   --wait        Poll for up to 5 minutes waiting for new bot comments
+#   --author      Filter to a specific author (e.g., "claude")
+
+set -euo pipefail
+
+# Load shared jq helpers
+source "$(dirname "${BASH_SOURCE[0]}")/_jq_helpers.sh"
+
+PR_NUMBER="${1:?Usage: get-pr-comments.sh <pr-number> [--with-ids] [--wait] [--author <login>]}"
+shift
+
+WITH_IDS=false
+WAIT_FOR_COMMENTS=false
+WAIT_TIMEOUT=300  # 5 minutes
+POLL_INTERVAL=30
+AUTHOR_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-ids)
+            WITH_IDS=true
+            shift
+            ;;
+        --wait)
+            WAIT_FOR_COMMENTS=true
+            shift
+            ;;
+        --author)
+            AUTHOR_FILTER="${2:?--author requires a value}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Get repo info (needed for all gh calls to work from worktrees or when origin remote differs)
+REPO=$(git remote get-url origin 2>/dev/null | sed 's/.*github\.com[:\/]//' | sed 's/\.git$//')
+
+# Validate PR number to fail fast on invalid input
+if ! gh pr view "$PR_NUMBER" -R "$REPO" --json number &> /dev/null; then
+    echo "Error: Pull request #$PR_NUMBER not found or access denied." >&2
+    exit 1
+fi
+
+# Default bot pattern (regex); --author uses exact match instead
+BOT_PATTERN="claude|cursor|copilot|gemini-code-assist"
+EXACT_MATCH=false
+if [[ -n "$AUTHOR_FILTER" ]]; then
+    BOT_PATTERN="$AUTHOR_FILTER"
+    EXACT_MATCH=true
+fi
+
+# jq filter: exact case-insensitive match for --author, regex for default
+JQ_SELECT='select(if $exact then (.author.login | ascii_downcase) == ($pattern | ascii_downcase) else .author.login | test($pattern; "i") end)'
+
+# Function to get bot PR comment count
+get_bot_comment_count() {
+    gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
+        --arg pattern "$BOT_PATTERN" --argjson exact "$EXACT_MATCH" \
+        --jq "[.comments[] | $JQ_SELECT] | length" 2>/dev/null || echo 0
+}
+
+# If --wait, poll until bot comments exist or timeout
+if [[ "$WAIT_FOR_COMMENTS" == "true" ]]; then
+    INITIAL_COUNT=$(get_bot_comment_count)
+
+    if [[ "$INITIAL_COUNT" -gt 0 ]]; then
+        echo "Found $INITIAL_COUNT bot PR comment(s), proceeding..."
+        echo ""
+    else
+        ELAPSED=0
+        echo "Waiting for bot PR comments (current: 0)..."
+        echo "Will poll every ${POLL_INTERVAL}s for up to ${WAIT_TIMEOUT}s (5 minutes)"
+        echo ""
+
+        while [[ $ELAPSED -lt $WAIT_TIMEOUT ]]; do
+            sleep "$POLL_INTERVAL"
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+
+            CURRENT_COUNT=$(get_bot_comment_count)
+
+            if [[ "$CURRENT_COUNT" -gt 0 ]]; then
+                echo "Bot PR comments detected! ($CURRENT_COUNT comments)"
+                echo ""
+                break
+            fi
+
+            echo "Still waiting... (${ELAPSED}s/${WAIT_TIMEOUT}s)"
+        done
+
+        if [[ $ELAPSED -ge $WAIT_TIMEOUT ]]; then
+            FINAL_COUNT=$(get_bot_comment_count)
+            if [[ "$FINAL_COUNT" -eq 0 ]]; then
+                echo "No bot PR comments after ${WAIT_TIMEOUT}s."
+                echo ""
+                exit 0
+            fi
+        fi
+    fi
+fi
+
+# Fetch bot PR comments
+COMMENTS=$(gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
+    --arg pattern "$BOT_PATTERN" --argjson exact "$EXACT_MATCH" \
+    --jq "[.comments[] | $JQ_SELECT | {id: .id, author: .author.login, createdAt: .createdAt, body: .body}]" 2>/dev/null || echo "[]")
+
+if [[ "$COMMENTS" == "[]" ]] || [[ -z "$COMMENTS" ]]; then
+    echo "No PR comments found from bot reviewers."
+    exit 0
+fi
+
+TOTAL=$(echo "$COMMENTS" | jq 'length')
+echo "Found $TOTAL bot PR comment(s):"
+echo ""
+
+# Process and output each comment
+echo "$COMMENTS" | jq -r --argjson withIds "$WITH_IDS" "$PRIORITY_DETECT"'
+    .[] |
+    (.body | detect_priority) as $priority |
+    if $withIds then
+        "=== Comment ID: \(.id) | Author: \(.author) | \(.createdAt) ===",
+        "Priority: \($priority)",
+        "",
+        .body,
+        "",
+        "---",
+        ""
+    else
+        "=== Author: \(.author) | \(.createdAt) ===",
+        "Priority: \($priority)",
+        "",
+        (.body | split("\n") | .[0:5] | join("\n")),
+        "... (use --with-ids for full text)",
+        "",
+        "---",
+        ""
+    end
+'
+
+# Summary by author
+echo ""
+echo "## Summary"
+echo "$COMMENTS" | jq -r 'group_by(.author) | .[] | "\(.[0].author): \(length) comment(s)"'

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/get-pr-comments.sh
@@ -53,21 +53,20 @@ if ! gh pr view "$PR_NUMBER" -R "$REPO" --json number &> /dev/null; then
     exit 1
 fi
 
-# Default bot pattern (regex); --author uses exact match instead
-BOT_PATTERN="claude|cursor|copilot|gemini-code-assist"
-EXACT_MATCH=false
+# Build jq select filter inline — gh pr view --jq does not support --arg/--argjson,
+# so the pattern is interpolated into the filter string by the shell.
 if [[ -n "$AUTHOR_FILTER" ]]; then
-    BOT_PATTERN="$AUTHOR_FILTER"
-    EXACT_MATCH=true
+    # Exact case-insensitive match on the author filter; lowercase in shell before inlining
+    LOWER_AUTHOR=$(printf '%s' "$AUTHOR_FILTER" | tr '[:upper:]' '[:lower:]')
+    JQ_SELECT="select((.author.login | ascii_downcase) == \"$LOWER_AUTHOR\")"
+else
+    # Regex match against the default bot pattern
+    JQ_SELECT='select(.author.login | test("claude|cursor|copilot|gemini-code-assist"; "i"))'
 fi
-
-# jq filter: exact case-insensitive match for --author, regex for default
-JQ_SELECT='select(if $exact then (.author.login | ascii_downcase) == ($pattern | ascii_downcase) else .author.login | test($pattern; "i") end)'
 
 # Function to get bot PR comment count
 get_bot_comment_count() {
     gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
-        --arg pattern "$BOT_PATTERN" --argjson exact "$EXACT_MATCH" \
         --jq "[.comments[] | $JQ_SELECT] | length" 2>/dev/null || echo 0
 }
 
@@ -110,10 +109,9 @@ if [[ "$WAIT_FOR_COMMENTS" == "true" ]]; then
     fi
 fi
 
-# Fetch bot PR comments
+# Fetch bot PR comments (let gh failures propagate via set -e)
 COMMENTS=$(gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
-    --arg pattern "$BOT_PATTERN" --argjson exact "$EXACT_MATCH" \
-    --jq "[.comments[] | $JQ_SELECT | {id: .id, author: .author.login, createdAt: .createdAt, body: .body}]" 2>/dev/null || echo "[]")
+    --jq "[.comments[] | $JQ_SELECT | {id: .id, author: .author.login, createdAt: .createdAt, body: .body}]")
 
 if [[ "$COMMENTS" == "[]" ]] || [[ -z "$COMMENTS" ]]; then
     echo "No PR comments found from bot reviewers."

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/trigger-review.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/trigger-review.sh
@@ -165,7 +165,7 @@ gemini_has_reviewed() {
     local sha="$1"
     local count
     count=$(gh api --paginate "repos/$OWNER/$REPO_NAME/pulls/$PR_NUMBER/reviews" \
-      | jq --arg sha "$sha" '[.[] | select((.user.login == "gemini-code-assist[bot]" or .user.login == "gemini-code-assist") and .commit_id == $sha)] | length') || {
+      | jq -s --arg sha "$sha" 'add | [.[] | select((.user.login == "gemini-code-assist[bot]" or .user.login == "gemini-code-assist") and .commit_id == $sha)] | length') || {
         echo "Warning: Failed to check Gemini review status via API. Assuming not reviewed." >&2
         count=0
     }

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/trigger-review.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/trigger-review.sh
@@ -3,7 +3,9 @@
 # Usage: trigger-review.sh [pr-number] [--gemini|--cursor|--claude] [--wait]
 #
 # This script supports multiple review bot types:
-# - Gemini Code Assist: Manually triggered via /gemini review comment
+# - Gemini Code Assist: Triggered via /gemini review comment, but skipped if
+#   Gemini has already reviewed the current commit (e.g., auto-review on push).
+#   Also checks for .gemini/config.yaml to detect repos with auto-review enabled.
 # - Cursor Bugbot: Auto-reviews on push (no manual trigger needed)
 # - Claude: Fallback using a Claude agent to review the PR
 #
@@ -149,10 +151,51 @@ get_comment_count() {
     echo "$count"
 }
 
-# Only Gemini needs a manual trigger command
+# Check if repo has Gemini auto-review configured (.gemini/config.yaml with code_review: true)
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+GEMINI_AUTO_REVIEW=false
+if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.gemini/config.yaml" ]]; then
+    if grep -qEi '^[[:space:]]*code_review:[[:space:]]*true[[:space:]]*$' "$REPO_ROOT/.gemini/config.yaml" 2>/dev/null; then
+        GEMINI_AUTO_REVIEW=true
+    fi
+fi
+
+# Check if Gemini has already reviewed a specific commit
+gemini_has_reviewed() {
+    local sha="$1"
+    local count
+    count=$(gh api --paginate "repos/$OWNER/$REPO_NAME/pulls/$PR_NUMBER/reviews" \
+      | jq --arg sha "$sha" '[.[] | select((.user.login == "gemini-code-assist[bot]" or .user.login == "gemini-code-assist") and .commit_id == $sha)] | length') || {
+        echo "Warning: Failed to check Gemini review status via API. Assuming not reviewed." >&2
+        count=0
+    }
+    [[ "$count" -gt 0 ]]
+}
+
+# Only Gemini needs a manual trigger command — but skip if already reviewed this commit
 if [[ "$BOT_TYPE" == "gemini" ]]; then
-    gh pr comment "$PR_NUMBER" -R "$REPO" --body "/gemini review"
-    echo "Review requested."
+    CURRENT_SHA=$(git rev-parse HEAD)
+
+    if gemini_has_reviewed "$CURRENT_SHA"; then
+        echo "Gemini already reviewed commit ${CURRENT_SHA:0:7}, skipping manual trigger."
+    elif [[ "$GEMINI_AUTO_REVIEW" == "true" && "$WAIT_FOR_COMMENTS" == "true" ]]; then
+        # Repo has auto-review configured — wait one interval for it before triggering manually
+        echo "Auto-review detected in .gemini/config.yaml. Waiting ${POLL_INTERVAL}s for auto-review..."
+        sleep "$POLL_INTERVAL"
+
+        if gemini_has_reviewed "$CURRENT_SHA"; then
+            echo "Gemini auto-reviewed commit ${CURRENT_SHA:0:7}, skipping manual trigger."
+        else
+            echo "No auto-review yet. Triggering manually..."
+            gh pr comment "$PR_NUMBER" -R "$REPO" --body "/gemini review"
+            echo "Review requested."
+        fi
+        # Account for the grace period in the wait timeout below
+        GRACE_ELAPSED=$POLL_INTERVAL
+    else
+        gh pr comment "$PR_NUMBER" -R "$REPO" --body "/gemini review"
+        echo "Review requested."
+    fi
 fi
 
 if [[ "$WAIT_FOR_COMMENTS" == "true" ]]; then
@@ -166,12 +209,15 @@ if [[ "$WAIT_FOR_COMMENTS" == "true" ]]; then
         exit 0
     fi
 
+    # Account for any grace period already waited
+    ELAPSED=${GRACE_ELAPSED:-0}
+    REMAINING=$((WAIT_TIMEOUT - ELAPSED))
+
     echo ""
     echo "Waiting for review comments..."
-    echo "Will poll every ${POLL_INTERVAL}s for up to ${WAIT_TIMEOUT}s (5 minutes)"
+    echo "Will poll every ${POLL_INTERVAL}s for up to ${REMAINING}s"
     echo ""
 
-    ELAPSED=0
     while [[ $ELAPSED -lt $WAIT_TIMEOUT ]]; do
         sleep "$POLL_INTERVAL"
         ELAPSED=$((ELAPSED + POLL_INTERVAL))


### PR DESCRIPTION
## Summary

Ports selected features and guidance blocks from the independently-evolved `Valid-Eval/valid-eval-skills` copy of the `pr-review-loop` skill. Excludes their changes we've already landed (hierarchical `discover-agents.sh` via #8, CI `--repo` handling via #6) and their `gh repo view --json nameWithOwner` REPO-derivation pattern (strictly worse than our `git remote get-url origin` on forked repos).

Four commits, one per concern:

1. **`trigger-review.sh`** — two quota-saving checks before `/gemini review`:
   - Skip if Gemini has already reviewed the current HEAD commit.
   - If `.gemini/config.yaml` has `code_review: true` and `--wait` is set, wait one poll interval for an auto-review before falling back to manual trigger.
2. **`get-pr-comments.sh` (new)** — fetches PR-level bot comments (Claude, Cursor, Copilot, gemini-code-assist) with priority detection via `_jq_helpers.sh`. Supports `--with-ids`, `--wait`, and `--author` exact-match filtering.
3. **SKILL.md guidance additions**:
   - Self-Contradiction Detection (pause when round N reverses a prior fix).
   - Stopping Heuristics (replaces Diminishing Returns Detection): per-round assessment table, continue/stop thresholds, hard 7-round / 5-nitpick-only ceiling.
   - Merge Readiness section: CI-status check, repo-specific merge guidance, structured summary, auto-merge-vs-ask logic. Links back to the existing CI Fix Loop.
   - Beads-absent `TODO-beads.md` fallback: collect out-of-scope findings across rounds and offer a follow-up PR with pre-filled `bd create` commands.
   - "Suggesting AGENT-REVIEWERS.md Creation or Updates" guidance.
   - Expanded Gemini quota doc note and `get-pr-comments.sh` entries in the Scripts table and Permission Setup block.
4. **`AGENT-REVIEWERS.md`**:
   - New `shell-script-reviewer` agent.
   - Four new guideline bullets (SKILL.md as agent instructions, verify factual claims, check prior responses, check `.beads/` before flagging pre-existing issues).
   - marketplace-reviewer flag: new skill directories missing `SKILL.md`.
   - clarity-reviewer: explicit "Do NOT flag" for deliberate rule repetition in SKILL.md / references/*.md.
   - Scrubbed the "purpose-built for Valid Eval" bullet from the source — not applicable here.

## Explicit skips (from planning, for the record)

- **Evidence Gates table** — half the rows are Rails/FactoryBot-shaped (`create` → `build_stubbed`, Rails migration templates). Not generic enough to port.
- **Phase-based COLLECT/FIX rounds + priority-mapping table** — conflicts with our per-reviewer commit flow.
- **Their `gh repo view --json nameWithOwner` REPO derivation** — picks the wrong remote on forked repos.
- **Their "Autonomous Loop Workflow" CRITICAL RULES list** — omits the "ALWAYS use full absolute paths for scripts" rule that our plugin layout requires.

## Test plan

- [ ] `bash -n` passes on both scripts (verified locally).
- [ ] `pre-commit run` (shellcheck + standard hygiene) passes on both scripts (verified locally).
- [ ] `grep -rni 'valid.eval\\|valideval' plugins/ AGENT-REVIEWERS.md` returns zero matches (verified locally).
- [ ] Run `trigger-review.sh <PR>` against a PR where Gemini has already reviewed HEAD → expect skip message, no `/gemini review` posted.
- [ ] Run `trigger-review.sh <PR>` against a PR where HEAD has no Gemini review → expect manual trigger as before.
- [ ] Run `get-pr-comments.sh <PR> --with-ids` on a PR with a Claude/Cursor PR-level comment → expect IDs, priority, and body. Confirm `--author claude` applies exact-match filter.
- [ ] Review this PR with the review loop itself as a smoke test; confirm Gemini is not re-triggered redundantly on an already-reviewed HEAD.
- [ ] `shell-script-reviewer` picked up by `discover-agents.sh` when a PR touches `*.sh` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)