### PR TITLE
fix(dream): gate runs on new input; stop losing markers and coverage

### DIFF
--- a/plugins/dream/scripts/dreamlib/cli.py
+++ b/plugins/dream/scripts/dreamlib/cli.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import argparse
 import glob
+import hashlib
 import json
 import os
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -88,6 +90,15 @@ def cmd_distill(args: argparse.Namespace) -> int:
         from .model import enrich as _enrich
 
         enrich = _enrich
+        # Say which box is doing the thinking. With $WYRD_OLLAMA_URL unset (an
+        # interactive run, or a cron unit missing the Environment= line) this
+        # silently defaults to localhost — which on some hosts is a weak-GPU box
+        # capped well below the intended model. Degrading quietly is worse than
+        # a loud line at the top of the run.
+        if not os.environ.get("WYRD_OLLAMA_URL"):
+            _echo(f"WARN: WYRD_OLLAMA_URL unset — distilling against {args.url}")
+        else:
+            _echo(f"distill model: {args.model} @ {args.url}")
 
     done = skipped = failed = selfrun = 0
     t0 = time.time()
@@ -290,25 +301,66 @@ def cmd_reviews_synth(args: argparse.Namespace) -> int:
     s = rv.synth(findings)
     s["source"] = args.source
     s["generated_at"] = _now()
-    with open(os.path.join(rv.REVIEW_OUT, "scorecards.json"), "w") as fh:
-        json.dump(s, fh, indent=2)
-    md = _render_scorecards(s)
-    with open(os.path.join(rv.REVIEW_OUT, "SCORECARDS.md"), "w") as fh:
-        fh.write(md)
+    # Suffix by source: both `--source markers` and `--source all` used to write
+    # the same two filenames, so running both left only the second — the markers
+    # scorecard (the only one carrying operator taste) was silently destroyed.
+    for name, blob in (
+        (f"scorecards-{args.source}.json", json.dumps(s, indent=2)),
+        (f"SCORECARDS-{args.source}.md", _render_scorecards(s)),
+    ):
+        with open(os.path.join(rv.REVIEW_OUT, name), "w") as fh:
+            fh.write(blob)
     _echo(
         f"reviews-synth: {s['reviewer_count']} scorecards "
-        f"→ {rv.REVIEW_OUT}/SCORECARDS.md"
+        f"→ {rv.REVIEW_OUT}/SCORECARDS-{args.source}.md"
     )
     return 0
 
 
+def _merge_coverage(old: dict, new: dict) -> dict:
+    """Cumulative max-by-reviewer merge.
+
+    Coverage is computed from the Claude Code session-log window, which is pruned:
+    the wyrd record went 1,360 spawns → 0 across six weeks with no reviewer actually
+    going quiet. Recomputing from the live window therefore *destroys* history, and
+    a naive reader would retire a productive reviewer for showing zero. Merging
+    forward makes the count a high-water mark instead of a snapshot."""
+    merged: dict[str, dict] = {r["reviewer"]: dict(r) for r in old.get("reviewers", [])}
+    for r in new.get("reviewers", []):
+        prev = merged.get(r["reviewer"])
+        if prev is None:
+            merged[r["reviewer"]] = dict(r)
+            continue
+        prev["spawns"] = max(prev.get("spawns") or 0, r.get("spawns") or 0)
+        prev["prs"] = max(prev.get("prs") or 0, r.get("prs") or 0)
+        seens = [s for s in (prev.get("first_seen"), r.get("first_seen")) if s]
+        prev["first_seen"] = min(seens) if seens else None
+        seens = [s for s in (prev.get("last_seen"), r.get("last_seen")) if s]
+        prev["last_seen"] = max(seens) if seens else None
+    out = dict(new)
+    out["reviewers"] = sorted(
+        merged.values(), key=lambda r: (-(r.get("spawns") or 0), r["reviewer"])
+    )
+    out["total_spawns"] = sum(r.get("spawns") or 0 for r in out["reviewers"])
+    out["live_window_spawns"] = new.get("total_spawns", 0)
+    return out
+
+
 def cmd_reviews_coverage(args: argparse.Namespace) -> int:
     cov = rv.coverage_from_logs()
-    cov["generated_at"] = _now()
     os.makedirs(rv.REVIEW_OUT, exist_ok=True)
-    with open(os.path.join(rv.REVIEW_OUT, "coverage.json"), "w") as fh:
+    path = os.path.join(rv.REVIEW_OUT, "coverage.json")
+    if not args.no_merge and os.path.exists(path):
+        try:
+            with open(path) as fh:
+                cov = _merge_coverage(json.load(fh), cov)
+        except Exception as e:  # noqa: BLE001 — a corrupt prior file must not
+            _echo(f"reviews-coverage: prior coverage unreadable ({e}) — not merged")
+    cov["generated_at"] = _now()
+    with open(path, "w") as fh:
         json.dump(cov, fh, indent=2)
-    lines = ["# Reviewer firing coverage (from logs — complete, unbiased)", ""]
+    lines = ["# Reviewer firing coverage (cumulative high-water mark, merged "
+             "forward across runs — the live log window is pruned)", ""]
     lines.append(f"{cov['total_spawns']} reviewer spawns\n")
     lines.append("| reviewer | spawns | PRs | first seen | last seen |")
     lines.append("|---|--:|--:|---|---|")
@@ -321,13 +373,87 @@ def cmd_reviews_coverage(args: argparse.Namespace) -> int:
         fh.write("\n".join(lines))
     _echo(
         f"reviews-coverage: {len(cov['reviewers'])} reviewers, "
-        f"{cov['total_spawns']} spawns → {rv.REVIEW_OUT}/COVERAGE.md"
+        f"{cov['total_spawns']} spawns cumulative "
+        f"({cov.get('live_window_spawns', cov['total_spawns'])} in the live window) "
+        f"→ {rv.REVIEW_OUT}/COVERAGE.md"
     )
     return 0
 
 
 def cmd_reviews_harvest(args: argparse.Namespace) -> int:
     rv.harvest(_echo)
+    return 0
+
+
+GATE_STATE = os.path.join(config.dream_home(), "gate.json")
+
+
+def _gate_state() -> dict:
+    try:
+        with open(GATE_STATE) as fh:
+            return json.load(fh)
+    except Exception:  # noqa: BLE001 — missing/corrupt state means "never ran"
+        return {}
+
+
+def _sessions_fingerprint() -> str:
+    """Content fingerprint of the minable corpus: the sorted input_hashes of every
+    non-self-run session. Content-keyed, never mtime — dream's own reads and the
+    log pruner both touch mtimes without changing what there is to mine."""
+    hashes = []
+    for f in _session_files(PROJECT_LOGS, skip_live=True):
+        try:
+            session = load_session(f)
+        except Exception:  # noqa: BLE001 — an unparseable log is not new input
+            continue
+        if not is_self_run(session):
+            hashes.append(session.input_hash)
+    if not hashes:
+        return "unavailable"
+    return hashlib.sha256("".join(sorted(hashes)).encode()).hexdigest()
+
+
+def _prs_fingerprint() -> str:
+    """Most recently touched PR (number + updatedAt). Catches a merge, a new PR, and
+    new review comments on an existing one — the three things that give the reviewer
+    roster new evidence."""
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "list", "--state", "all", "--limit", "1",
+             "--search", "sort:updated-desc", "--json", "number,updatedAt"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except Exception:  # noqa: BLE001
+        return "unavailable"
+    return r.stdout.strip() if r.returncode == 0 and r.stdout.strip() else "unavailable"
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    """Exit 0 when there is new input since the last passing gate, 1 when there is
+    not. Built for systemd ``ExecCondition=``, which skips the unit — without
+    marking it failed — on a 1-254 exit. A quiet day then produces no run, and so
+    no review/pending/ file for the triage job to turn into a digest.
+
+    Fails OPEN: when the signal can't be computed (gh down, no readable logs) the
+    run proceeds, so a broken probe never silently stalls the pipeline.
+    """
+    key = args.check
+    current = _sessions_fingerprint() if key == "sessions" else _prs_fingerprint()
+    if current == "unavailable":
+        _echo(f"gate[{key}]: signal unavailable — failing open, run proceeds")
+        return 0
+
+    state = _gate_state()
+    if state.get(key) == current:
+        _echo(f"gate[{key}]: no new input since last run — skipping")
+        return 1
+
+    if not args.peek:
+        state[key] = current
+        state[f"{key}_at"] = _now()
+        with open(GATE_STATE, "w") as fh:
+            json.dump(state, fh, indent=2)
+    _echo(f"gate[{key}]: new input since last run — run proceeds")
     return 0
 
 
@@ -362,10 +488,19 @@ def main(argv: list[str] | None = None) -> int:
     rs.set_defaults(func=cmd_reviews_synth)
 
     rc = sub.add_parser("reviews-coverage", help="reviewer firing coverage from logs")
+    rc.add_argument("--no-merge", action="store_true",
+                    help="live log window only; do not merge the prior cumulative file")
     rc.set_defaults(func=cmd_reviews_coverage)
 
     rh = sub.add_parser("reviews-harvest", help="capture durable + /tmp reviewer findings")
     rh.set_defaults(func=cmd_reviews_harvest)
+
+    g = sub.add_parser("gate", help="exit 1 when there is no new input since last run")
+    g.add_argument("--check", choices=["sessions", "prs"], default="sessions",
+                   help="sessions = new minable session content; prs = PR activity")
+    g.add_argument("--peek", action="store_true",
+                   help="report without advancing the watermark")
+    g.set_defaults(func=cmd_gate)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/plugins/dream/scripts/dreamlib/cli.py
+++ b/plugins/dream/scripts/dreamlib/cli.py
@@ -399,9 +399,16 @@ def _gate_state() -> dict:
 def _sessions_fingerprint() -> str:
     """Content fingerprint of the minable corpus: the sorted input_hashes of every
     non-self-run session. Content-keyed, never mtime — dream's own reads and the
-    log pruner both touch mtimes without changing what there is to mine."""
+    log pruner both touch mtimes without changing what there is to mine.
+
+    Unlike distill this does NOT skip the newest (possibly still-live) session.
+    Skipping it deadlocks: with every job gated off, no new log is ever written,
+    so the last real work session stays "newest" forever and never becomes
+    eligible. Counting it can only cost an extra run — and an extra run on a day
+    real work happened is the correct outcome. The hash changes again as the
+    session grows, which simply re-arms the gate."""
     hashes = []
-    for f in _session_files(PROJECT_LOGS, skip_live=True):
+    for f in _session_files(PROJECT_LOGS, skip_live=False):
         try:
             session = load_session(f)
         except Exception:  # noqa: BLE001 — an unparseable log is not new input

--- a/plugins/dream/scripts/dreamlib/config.py
+++ b/plugins/dream/scripts/dreamlib/config.py
@@ -32,10 +32,28 @@ def git_root(cwd: str | None = None) -> str:
     return _run(["git", "rev-parse", "--show-toplevel"], cwd=cwd or project_dir())
 
 
+def main_checkout(cwd: str | None = None) -> str:
+    """The MAIN checkout's root, even when called from a linked worktree.
+
+    `--show-toplevel` returns the *worktree* dir, so a review round run from
+    `wyrd-tombstone/` used to key its own `~/.dream/wyrd-tombstone/` — a slug that
+    dies with the worktree, taking its markers with it. The common dir is shared by
+    every worktree of a repo, so its parent is the one stable identity. Falls back
+    to the worktree root on old git (no `--path-format`) or a bare/odd layout."""
+    common = _run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=cwd or project_dir(),
+    )
+    if common.endswith("/.git"):
+        return os.path.dirname(common)
+    return git_root(cwd)
+
+
 def project_slug(cwd: str | None = None) -> str:
-    """Stable per-project key: the git-root basename (so a sibling producer like
-    pr-review-loop computes the SAME markers path with one `git rev-parse`)."""
-    root = git_root(cwd)
+    """Stable per-project key: the MAIN checkout's basename (so a sibling producer
+    like pr-review-loop computes the SAME markers path, and every worktree of a repo
+    writes to one stream)."""
+    root = main_checkout(cwd)
     return os.path.basename(root or os.path.abspath(cwd or project_dir()))
 
 

--- a/plugins/dream/scripts/dreamlib/reviews.py
+++ b/plugins/dream/scripts/dreamlib/reviews.py
@@ -241,13 +241,44 @@ def _canonical_reviewer_map(findings: list[dict]) -> dict[str, str]:
     AGENT-REVIEWERS.md convention). Folds ONLY when both variants are actually
     present — e.g. ``test-coverage`` (7) → ``test-coverage-reviewer`` (483),
     ``api-correctness`` ↔ ``api-correctness-reviewer`` — so genuinely-distinct
-    one-off names are never merged into a canonical they don't belong to."""
+    one-off names are never merged into a canonical they don't belong to.
+
+    The known-variant set is seeded from the ROSTER as well as from this finding
+    set. Seeding from the findings alone made the fold source-dependent: in a
+    ``--source markers`` run ``clarity`` had no ``clarity-reviewer`` sibling to
+    fold onto (the suffixed form only appears in the GitHub sample), so the same
+    reviewer scored as two rows there and one row under ``--source all`` — 80
+    scorecards for a ~30 reviewer roster. The roster is the naming authority, so
+    a bare name that matches a roster reviewer folds regardless of source."""
     names = {f["reviewer"] for f in findings if f.get("reviewer")}
+    known = names | roster_reviewers()
     out: dict[str, str] = {}
     for n in names:
         suffixed = n if n.endswith("-reviewer") else n + "-reviewer"
-        out[n] = suffixed if suffixed in names else n
+        out[n] = suffixed if suffixed in known else n
     return out
+
+
+def roster_reviewers() -> set[str]:
+    """Reviewer names declared by the repo: every ``.reviewers/<name>.md`` spec and
+    every ``## <name>`` heading in an AGENT-REVIEWERS.md. Empty set when the repo
+    has no roster — callers must treat that as "no extra knowledge", never as
+    "this reviewer is unknown, drop it"."""
+    names: set[str] = set()
+    root = config.git_root() or config.project_dir()
+    for spec in _glob.glob(os.path.join(root, "**", ".reviewers", "*.md"),
+                           recursive=True):
+        names.add(os.path.basename(spec)[:-3])
+    for roster in _glob.glob(os.path.join(root, "**", "AGENT-REVIEWERS.md"),
+                             recursive=True):
+        try:
+            with open(roster, encoding="utf-8") as fh:
+                for line in fh:
+                    if line.startswith("## "):
+                        names.add(line[3:].strip())
+        except OSError:
+            continue
+    return {n for n in names if re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", n)}
 
 
 def synth(findings: list[dict]) -> dict:

--- a/plugins/dream/tests/test_cli.py
+++ b/plugins/dream/tests/test_cli.py
@@ -40,3 +40,41 @@ def test_cache_fresh_model_error_is_retried_not_poisoned(tmp_path):
     assert cli._cache_fresh(p, "h1", want_model=True) is False
     # Without a model request it's still fine to reuse.
     assert cli._cache_fresh(p, "h1", want_model=False) is True
+
+
+# --- coverage merge-forward ------------------------------------------------
+# The session-log window is pruned, so recomputing coverage each run destroys
+# history (wyrd went 1,360 spawns -> 0 with no reviewer actually going quiet).
+
+
+def test_merge_coverage_keeps_high_water_mark():
+    old = {"total_spawns": 104, "reviewers": [
+        {"reviewer": "a-reviewer", "spawns": 100, "prs": 9,
+         "first_seen": "2026-06-01", "last_seen": "2026-07-08"},
+        {"reviewer": "b-reviewer", "spawns": 4, "prs": 1,
+         "first_seen": "2026-06-02", "last_seen": "2026-06-30"},
+    ]}
+    new = {"total_spawns": 0, "reviewers": []}  # window fully pruned
+    m = cli._merge_coverage(old, new)
+    assert m["total_spawns"] == 104
+    assert m["live_window_spawns"] == 0
+    assert {r["reviewer"] for r in m["reviewers"]} == {"a-reviewer", "b-reviewer"}
+
+
+def test_merge_coverage_extends_span_and_adds_new_reviewers():
+    old = {"total_spawns": 5, "reviewers": [
+        {"reviewer": "a-reviewer", "spawns": 5, "prs": 2,
+         "first_seen": "2026-06-01", "last_seen": "2026-06-10"},
+    ]}
+    new = {"total_spawns": 9, "reviewers": [
+        {"reviewer": "a-reviewer", "spawns": 7, "prs": 3,
+         "first_seen": "2026-06-05", "last_seen": "2026-07-01"},
+        {"reviewer": "c-reviewer", "spawns": 2, "prs": 1,
+         "first_seen": "2026-07-01", "last_seen": "2026-07-01"},
+    ]}
+    m = cli._merge_coverage(old, new)
+    a = next(r for r in m["reviewers"] if r["reviewer"] == "a-reviewer")
+    assert a["spawns"] == 7 and a["prs"] == 3       # max, not overwrite
+    assert a["first_seen"] == "2026-06-01"          # earliest ever seen
+    assert a["last_seen"] == "2026-07-01"           # latest ever seen
+    assert m["total_spawns"] == 9                   # 7 + 2

--- a/plugins/dream/tests/test_config.py
+++ b/plugins/dream/tests/test_config.py
@@ -54,3 +54,30 @@ def test_known_corpus_dedups_extra_corpus(tmp_path, monkeypatch):
     monkeypatch.setenv("DREAM_EXTRA_CORPUS", str(d))
     files = config.known_corpus_files(str(tmp_path))
     assert files.count(str(d)) == 1  # walk hit + extra-corpus hit deduped
+
+
+def test_project_slug_uses_main_checkout_from_worktree(monkeypatch):
+    """A linked worktree must key the SAME slug as its main checkout — otherwise
+    every worktree-based review round writes markers to an orphan dir."""
+    def fake_run(cmd, cwd=None):
+        if "--git-common-dir" in cmd:
+            return "/home/dev/proj/.git"
+        if "--show-toplevel" in cmd:
+            return "/home/dev/proj-feature"
+        return ""
+
+    monkeypatch.setattr(config, "_run", fake_run)
+    assert config.project_slug() == "proj"
+
+
+def test_project_slug_falls_back_when_no_common_dir(monkeypatch):
+    """Old git (no --path-format) or a bare layout: keep the previous behavior."""
+    def fake_run(cmd, cwd=None):
+        if "--git-common-dir" in cmd:
+            return ""
+        if "--show-toplevel" in cmd:
+            return "/home/dev/proj"
+        return ""
+
+    monkeypatch.setattr(config, "_run", fake_run)
+    assert config.project_slug() == "proj"

--- a/plugins/dream/tests/test_reviews.py
+++ b/plugins/dream/tests/test_reviews.py
@@ -210,3 +210,41 @@ def test_read_markers_enforces_kind_contract(markers_home):
     assert out[0]["reviewer"] == "code-reviewer"
     assert out[0]["disposition_by"] == "user"
     assert out[0]["pr"] == "33"
+
+
+# --- roster-seeded reviewer canonicalization -------------------------------
+# Seeding the fold from the finding set alone made it source-dependent: under
+# `--source markers`, `clarity` had no `clarity-reviewer` sibling to fold onto,
+# so one reviewer scored as two rows there and one row under `--source all`.
+
+
+def test_canonical_map_folds_bare_name_onto_roster_name(monkeypatch):
+    monkeypatch.setattr(reviews, "roster_reviewers", lambda: {"clarity-reviewer"})
+    findings = [{"reviewer": "clarity"}]  # suffixed form absent from THIS set
+    assert reviews._canonical_reviewer_map(findings)["clarity"] == "clarity-reviewer"
+
+
+def test_canonical_map_leaves_non_roster_names_alone(monkeypatch):
+    monkeypatch.setattr(reviews, "roster_reviewers", lambda: {"clarity-reviewer"})
+    findings = [{"reviewer": "gemini"}, {"reviewer": "both"}]
+    m = reviews._canonical_reviewer_map(findings)
+    assert m["gemini"] == "gemini" and m["both"] == "both"
+
+
+def test_canonical_map_still_folds_within_finding_set(monkeypatch):
+    """Original behavior survives when the roster is empty (non-roster repo)."""
+    monkeypatch.setattr(reviews, "roster_reviewers", lambda: set())
+    findings = [{"reviewer": "test-coverage"}, {"reviewer": "test-coverage-reviewer"}]
+    m = reviews._canonical_reviewer_map(findings)
+    assert m["test-coverage"] == "test-coverage-reviewer"
+
+
+def test_roster_reviewers_reads_specs_and_headings(tmp_path, monkeypatch):
+    (tmp_path / ".reviewers").mkdir()
+    (tmp_path / ".reviewers" / "spec-reviewer.md").write_text("x", encoding="utf-8")
+    (tmp_path / "AGENT-REVIEWERS.md").write_text(
+        "# Agents\n\n## heading-reviewer\n\n## Not A Name\n", encoding="utf-8")
+    monkeypatch.setattr(reviews.config, "git_root", lambda cwd=None: str(tmp_path))
+    names = reviews.roster_reviewers()
+    assert "spec-reviewer" in names and "heading-reviewer" in names
+    assert "Not A Name" not in names  # prose heading, not a reviewer slug

--- a/plugins/pr-review-loop/skills/pr-review-loop/scripts/emit-dream-marker.sh
+++ b/plugins/pr-review-loop/skills/pr-review-loop/scripts/emit-dream-marker.sh
@@ -38,8 +38,17 @@ _emit() {
   [ "$#" -ge 1 ] || return 0
   local kind="$1"; shift
 
-  local root slug home dir ts
+  local root common slug home dir ts
+  # Slug from the MAIN checkout, not the worktree: --show-toplevel returns the
+  # worktree dir, so a round run from a worktree (the mandated workflow in some
+  # repos) wrote to ~/.dream/<worktree-name>/ — an orphan slug the dream skill
+  # never reads. The common dir is shared by every worktree of a repo, so its
+  # parent is the one stable identity. Mirrors dreamlib/config.py:main_checkout.
   root="$(git rev-parse --show-toplevel 2>/dev/null)" || root="$PWD"
+  common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+  case "$common" in
+    */.git) root="${common%/.git}" ;;
+  esac
   slug="$(basename "$root")"
   home="${DREAM_HOME:-$HOME/.dream/$slug}"
   dir="$home/markers"


### PR DESCRIPTION
wyrd's dream review queue had grown to **24 pending digest files**. Reading all of them: 16 re-propose one identical one-line edit, and the rest carry the same 3-4 items forward. The queue's only growth was re-proposal.

Root cause is two compounding leaks, plus two data defects the digests carried for six weeks.

## 1. Runs fire with no new input — `dream gate`

`dream` and `dream-reviewers` ran nightly over a static corpus (90 of 93 wyrd sessions were dream's own self-runs), wrote a zero-proposal `review/pending/` file anyway, and the triage job turned each one into another `REVIEW-DIGEST`.

New `dream gate` exits 1 when there's no new input since the last **successful** run, for systemd `ExecCondition=` (which skips a unit without marking it failed):

- `--check sessions` — content fingerprint of the non-self-run session corpus (`input_hash`, never mtime: dream's own reads touch mtimes without changing what there is to mine)
- `--check prs` — watermark on the most recently touched PR, so a merge, a new PR, or new review comments all count as evidence
- `--peek` reports without advancing, so the unit can advance the watermark in `ExecStartPost` — a *failed* run is retried tomorrow rather than silently consumed
- Fails **open**: an uncomputable signal lets the run proceed

## 2. Markers were written to the worktree slug

`git rev-parse --show-toplevel` returns the *worktree* dir, so a review round run from a worktree — the mandated workflow in wyrd — wrote to `~/.dream/<worktree-name>/`, an orphan slug that dies with the worktree. **10 findings across 7 such dirs** were invisible to `dream-reviewers`.

Both producers (`dreamlib/config.py` and pr-review-loop's `emit-dream-marker.sh`) now resolve the git **common** dir, which every worktree of a repo shares. Verified in a real worktree: both implementations agree on `myrepo`, not `myrepo-feature`. Falls back to the old behavior on old git.

## 3. `reviews-coverage` destroyed its own history

It recomputed from the live session-log window, which is pruned — wyrd's record went **1,360 spawns → 0** with no reviewer actually going quiet. A naive reader would retire a productive reviewer for showing zero. Now merges forward as a max-by-reviewer high-water mark, keeping the live-window figure alongside as `live_window_spawns`. `--no-merge` restores the old behavior.

## 4. `reviews-synth` clobbered its own output

It wrote the same two filenames for every `--source`, so running `markers` then `all` silently destroyed the markers scorecard — the only one carrying operator taste. Output is now suffixed by source.

Plus: `distill` announces which ollama it's using and WARNs when `$WYRD_OLLAMA_URL` is unset (that silently defaults to localhost, a weak-GPU box on this host).

## Testing

- 60 plugin tests pass, including new cases for worktree slug resolution (+ old-git fallback) and the coverage high-water merge
- All 4 pr-review-loop test scripts pass
- `emit-dream-marker.sh` verified end-to-end from a real worktree
- `ExecCondition` skip verified live: `Skipped due to 'exec-condition'`, unit not marked failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)